### PR TITLE
Adapter apps: adapter-initiated write channel + session-identity-at-init

### DIFF
--- a/docs/android/guides/adapter-apps/README.md
+++ b/docs/android/guides/adapter-apps/README.md
@@ -46,16 +46,15 @@ lifecycle, and routing parsed values into its dashboards.
 ```kotlin
 class BoschEBikeAdapterService : LocusParserAdapterService() {
 
-    override fun init(bindContext: LocusBindContext): Int {
-        // Bind context tells us which refIds Locus understands and the running
-        // Locus's version. Bail with INIT_INCOMPATIBLE_API if you detect a
-        // finer-grained mismatch the XML apiVersion filter didn't catch.
+    override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
+        // deviceTypeId picks the protocol for this device; keep a deviceId -> deviceTypeId map if you
+        // need it in parseData. bindContext tells you which refIds Locus understands + its version —
+        // bail with INIT_INCOMPATIBLE_API on a finer-grained mismatch the XML apiVersion filter missed.
         return AdapterApi.INIT_OK
     }
 
     override fun parseData(
         deviceId: String,
-        deviceTypeId: String,
         source: String,
         bytes: ByteArray,
     ): SensorValueBatch? {
@@ -63,7 +62,6 @@ class BoschEBikeAdapterService : LocusParserAdapterService() {
         // `source` is the characteristic UUID for BT4, empty for stream transports.
         // Owns frame-reassembly state. Return null when bytes were consumed
         // without producing values (partial frame).
-        if (deviceTypeId != "bosch-ldi") return null
         val decoded = BoschLiveDataDecoder.decode(bytes) ?: return null
         return SensorValueBatchBuilder(System.currentTimeMillis())
             .put(LocusVariable.HeartRate, decoded.heartRate)
@@ -78,9 +76,9 @@ class BoschEBikeAdapterService : LocusParserAdapterService() {
 The `LocusVariable.X` constants are typed: writing a `Float` to a
 `LocusVariable<Int>` slot is a compile error, not a runtime surprise.
 
-The `deviceTypeId` parameter matches an `<deviceType id="...">` from your
-manifest XML — adapters that handle multiple device types (e.g. Bosch +
-Shimano under one adapter) switch on it for protocol-specific parsing.
+The session's `deviceTypeId` (from `init`) matches an `<deviceType id="...">` from your manifest
+XML — adapters that handle multiple device types (e.g. Bosch + Shimano under one adapter) keep a
+`deviceId → deviceTypeId` map and switch on it for protocol-specific parsing.
 
 ## Versioning
 

--- a/docs/android/guides/adapter-apps/aidl-contract.md
+++ b/docs/android/guides/adapter-apps/aidl-contract.md
@@ -50,16 +50,14 @@ without binding any adapter.
 
 ```kotlin
 override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
-    // deviceId / deviceTypeId — the device this bind is for; keep a deviceId -> deviceTypeId map
-    //   if you need the type in later parseData calls (they carry only deviceId)
-    // bindContext.supportedRefIds — which Locus Variables this Locus build understands
-    // bindContext.locusApiVersion — the adapter API version Locus speaks
-    // bindContext.locusPackageName / locusVersionName — running Locus identification
-    // Optional connect-time handshake (writable transports only):
-    // writeData(deviceId, listOf(AdapterWrite(CMD_UUID, ENABLE_CMD)))
     return AdapterApi.INIT_OK
 }
 ```
+
+`deviceId` / `deviceTypeId` identify the device this bind is for — keep a `deviceId → deviceTypeId`
+map if you need the type in later `parseData` calls (they carry only `deviceId`). `bindContext`
+carries Locus's `supportedRefIds`, `locusApiVersion`, and package / version. On a writable transport
+you may send a connect-time handshake here: `writeData(deviceId, listOf(AdapterWrite(cmdUuid, enableCmd)))`.
 
 Return one of:
 
@@ -78,15 +76,13 @@ override fun parseData(
     source: String,
     bytes: ByteArray,
 ): SensorValueBatch? {
-    // deviceId — the BLE MAC / USB id / adapter-internal token of the connected peer; the
-    //            deviceTypeId was established at init(), so look it up in your own
-    //            deviceId -> deviceTypeId map if you need to branch on protocol
-    // source   — characteristic UUID for BT4; empty string for stream transports (BT3/USB/NET)
-    // bytes    — raw payload, as Locus received it from the transport
+    …
 }
 ```
 
-Return either:
+`source` is the characteristic UUID for BT4, the empty string for stream transports (BT3 / USB).
+`deviceTypeId` was established at `init` — keep a `deviceId → deviceTypeId` map if you branch on
+protocol. Return either:
 
 - A
   [`SensorValueBatch`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/SensorValueBatch.kt)

--- a/docs/android/guides/adapter-apps/aidl-contract.md
+++ b/docs/android/guides/adapter-apps/aidl-contract.md
@@ -128,7 +128,7 @@ shouldn't wait for inbound data. No-op if the transport is read-only or the sess
 ### `getIntentForSettings`
 
 Returns an `Intent` Locus launches when the user taps "Settings" on
-[deviceId]'s picker row, or `null` for adapters with no settings UI.
+`deviceId`'s picker row, or `null` for adapters with no settings UI.
 
 Used in the `INIT_NEED_USER_ACTION` flow: if your adapter needs credentials /
 permissions / in-app pairing before it can work, return that flow's Activity

--- a/docs/android/guides/adapter-apps/aidl-contract.md
+++ b/docs/android/guides/adapter-apps/aidl-contract.md
@@ -33,7 +33,7 @@ This page walks the surface call-by-call.
 
 > **NET is reserved.** `AdapterApi.ConnectionType.NET` (read-only TCP stream) exists in the enum
 > and the contract is transport-neutral, but Locus does not drive NET yet — a `NET` device type is
-> parsed and skipped. v1 ships BT3 / BT4 / USB; NET (and write-back dispatch) land later with no
+> parsed and skipped. v1 ships BT3 / BT4 / USB (read **and** write); NET lands later with no
 > contract change. Build against BT3 / BT4 / USB for now.
 
 Note: there's no `getAvailableDevices()` AIDL call. Locus owns the device list
@@ -49,10 +49,14 @@ without binding any adapter.
 ### `init`
 
 ```kotlin
-override fun init(bindContext: LocusBindContext): Int {
+override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
+    // deviceId / deviceTypeId — the device this bind is for; keep a deviceId -> deviceTypeId map
+    //   if you need the type in later parseData calls (they carry only deviceId)
     // bindContext.supportedRefIds — which Locus Variables this Locus build understands
     // bindContext.locusApiVersion — the adapter API version Locus speaks
     // bindContext.locusPackageName / locusVersionName — running Locus identification
+    // Optional connect-time handshake (writable transports only):
+    // writeData(deviceId, listOf(AdapterWrite(CMD_UUID, ENABLE_CMD)))
     return AdapterApi.INIT_OK
 }
 ```
@@ -62,7 +66,7 @@ Return one of:
 | Code | When |
 |---|---|
 | `INIT_OK` | Adapter is ready. Locus starts driving the transport. |
-| `INIT_NEED_USER_ACTION` | Adapter needs one-time setup (credentials, runtime permission, in-app device pairing). Locus launches `getIntentForSettings()` and re-tries `init` afterwards. |
+| `INIT_NEED_USER_ACTION` | Adapter needs one-time setup (credentials, runtime permission, in-app device pairing). Locus launches `getIntentForSettings(deviceId)` and re-tries `init` afterwards. |
 | `INIT_INCOMPATIBLE_API` | Adapter can't operate against this Locus's API version. Locus surfaces an error and skips. (XML pre-filtering catches most cases; this is the runtime fallback when the adapter detects a finer-grained mismatch.) |
 | `INIT_ERROR` | Generic failure. Prefer the specific codes above when applicable. |
 
@@ -71,15 +75,14 @@ Return one of:
 ```kotlin
 override fun parseData(
     deviceId: String,
-    deviceTypeId: String,
     source: String,
     bytes: ByteArray,
 ): SensorValueBatch? {
-    // deviceId       — the BLE MAC / USB id / adapter-internal token of the connected peer
-    // deviceTypeId   — matches a <deviceType id="..."> from your manifest XML;
-    //                  branch on this if your adapter supports multiple device types
-    // source         — characteristic UUID for BT4; empty string for stream transports (BT3/USB/NET)
-    // bytes          — raw payload, as Locus received it from the transport
+    // deviceId — the BLE MAC / USB id / adapter-internal token of the connected peer; the
+    //            deviceTypeId was established at init(), so look it up in your own
+    //            deviceId -> deviceTypeId map if you need to branch on protocol
+    // source   — characteristic UUID for BT4; empty string for stream transports (BT3/USB/NET)
+    // bytes    — raw payload, as Locus received it from the transport
 }
 ```
 
@@ -112,17 +115,24 @@ Variables you're allowed to write to are the curated set in
 
 #### Write-backs
 
-Some protocols require a control / ACK write to the device. Schedule it via
-`Builder.writeBack(target, bytes)`; Locus dispatches it after applying the batch, but **only on
-writable transports** (BT4 / BT3 / USB — never read-only NET; a write for a non-writable transport
-is dropped). `target` is the characteristic UUID for BT4 (which must declare
+Some protocols require a control / ACK write to the device. There are two ways to write, both gated
+to **writable transports** (BT4 / BT3 / USB — never read-only NET; a write for a non-writable
+transport is dropped). `target` is the characteristic UUID for BT4 (which must declare
 `AdapterApi.CharacteristicMode.WRITE` in the manifest); for stream transports pass an empty string —
-the bytes go to the single open stream.
+the bytes go to the single open stream. Writes from both paths run on one ordered lane.
+
+**Reactive** — return writes alongside parsed values: `Builder.writeBack(target, bytes)`; Locus
+dispatches them right after applying the batch. Use this for ACKs / responses to received data.
+
+**Adapter-initiated** — call `writeData(deviceId, writes)` (provided by `LocusParserAdapterService`)
+any time the session is open, independent of `parseData`. Use this for a connect-time handshake
+(from `init`), a periodic poll on your own timer, or an event-driven command — anything that
+shouldn't wait for inbound data. No-op if the transport is read-only or the session has ended.
 
 ### `getIntentForSettings`
 
-Returns an `Intent` Locus launches when the user taps "Settings" on the
-adapter's picker row, or `null` for adapters with no settings UI.
+Returns an `Intent` Locus launches when the user taps "Settings" on
+[deviceId]'s picker row, or `null` for adapters with no settings UI.
 
 Used in the `INIT_NEED_USER_ACTION` flow: if your adapter needs credentials /
 permissions / in-app pairing before it can work, return that flow's Activity
@@ -134,7 +144,7 @@ component, action, data URI, extras, flags. Before launching, Locus must
 re-anchor it to the adapter's package and strip cross-package grants:
 
 ```kotlin
-val intent = adapter.getIntentForSettings() ?: return
+val intent = adapter.getIntentForSettings(deviceId) ?: return
 intent.setPackage(adapterPackageName)        // pin to the adapter's package
 intent.component?.let {
     require(it.packageName == adapterPackageName)
@@ -156,8 +166,14 @@ host.
 
 ### `shutdown`
 
-Called when the user unpairs or Locus shuts down. Release per-pairing state —
-parser buffers, in-flight callbacks, background coroutines.
+```kotlin
+override fun shutdown(deviceId: String) {
+    // release only this device's state — buffers, timers, handles
+}
+```
 
-The base class's default is a no-op. Override only for adapters that hold
-resources beyond the bind lifecycle.
+Called once per bound device when the user unpairs, the device disconnects, or Locus shuts down —
+`deviceId` matches `init` / `parseData`, so a multi-device adapter releases just that device's
+state. The base class drops that device's write channel before this runs.
+
+The base class's default is a no-op. Override only for adapters that hold per-device resources.

--- a/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl
+++ b/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl
@@ -59,13 +59,13 @@ interface ILocusSensorAdapterParser {
 
     /**
      * Optional intent the adapter wants Locus to launch when the user taps "Settings"
-     * on [deviceId]'s row in the picker.
+     * on {@code deviceId}'s row in the picker.
      */
     @nullable Intent getIntentForSettings(String deviceId);
 
     /**
-     * Tear down per-pairing state for [deviceId]. Called by Locus on unpair / disconnect / app
-     * shutdown, once per bound device (mirrors the [deviceId] of `init` / `parseData`).
+     * Tear down per-pairing state for {@code deviceId}. Called by Locus on unpair / disconnect / app
+     * shutdown, once per bound device (mirrors the {@code deviceId} of {@code init} / {@code parseData}).
      */
     void shutdown(String deviceId);
 }

--- a/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl
+++ b/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl
@@ -4,9 +4,10 @@ package locus.api.android.features.sensorAdapter.parser;
 import android.content.Intent;
 import locus.api.android.features.sensorAdapter.LocusBindContext;
 import locus.api.android.features.sensorAdapter.parser.SensorValueBatch;
+import locus.api.android.features.sensorAdapter.parser.ILocusSensorWriteChannel;
 
 /**
- * Bound service interface for adapter apps: Locus owns the BT/USB/ANT/... transport,
+ * Bound service interface for adapter apps: Locus owns the BT3 / BT4 / USB transport,
  * scanning, pairing, and GATT lifecycle. The adapter only declares its device types in
  * `res/xml/locus_adapter.xml` and implements byte-frame parsing here.
  *
@@ -18,11 +19,24 @@ import locus.api.android.features.sensorAdapter.parser.SensorValueBatch;
 interface ILocusSensorAdapterParser {
 
     /**
-     * Negotiate startup. Locus passes its own identification + the set of refIds it
-     * understands; adapter returns one of the INIT_* result codes from {@code AdapterApi}.
-     * Called once per bind.
+     * Negotiate startup for one bound device. Establishes the session identity — every other call
+     * carries just {@code deviceId}; the adapter keeps a {@code deviceId → deviceTypeId} mapping
+     * itself if it needs the type later. Locus passes its identification + the refIds it understands
+     * in {@code bindContext}; adapter returns one of the INIT_* result codes from {@code AdapterApi}.
+     * Called once per bound device.
+     *
+     * @param deviceId      stable instance id Locus assigned at pairing (BLE MAC, USB id, …)
+     * @param deviceTypeId  matches an `<deviceType id="...">` from the manifest XML; lets adapters
+     *                      that support multiple device types pick the protocol for this device
+     * @param writeChannel  callback for adapter-initiated writes (connect handshake, periodic poll,
+     *                      event). Null when the device type's transport is read-only. The adapter
+     *                      may call it any time the session is open; see {@code ILocusSensorWriteChannel}.
      */
-    int init(in LocusBindContext bindContext);
+    int init(
+        String deviceId,
+        String deviceTypeId,
+        in LocusBindContext bindContext,
+        @nullable ILocusSensorWriteChannel writeChannel);
 
     /**
      * Parse one inbound data unit from the device. For BT4 that's a single GATT notification /
@@ -31,28 +45,27 @@ interface ILocusSensorAdapterParser {
      * spans multiple physical packets, it buffers across calls and returns null for the early
      * fragments.
      *
-     * @param deviceId      stable instance id Locus assigned at pairing (BLE MAC, USB id, …)
-     * @param deviceTypeId  matches an `<deviceType id="...">` from the manifest XML;
-     *                      lets adapters that support multiple device types switch on
-     *                      it for protocol-specific parsing
-     * @param source        characteristic UUID for BT4; empty string for stream transports
-     * @param bytes         raw payload
+     * @param deviceId  the device this data is from (the {@code deviceTypeId} was established at
+     *                  {@code init}; look it up in your own {@code deviceId → deviceTypeId} map if
+     *                  you need to branch on protocol)
+     * @param source    characteristic UUID for BT4; empty string for stream transports
+     * @param bytes     raw payload
      * @return parsed batch, or null if consumed without producing values (e.g. partial frame)
      */
     @nullable SensorValueBatch parseData(
         String deviceId,
-        String deviceTypeId,
         String source,
         in byte[] bytes);
 
     /**
      * Optional intent the adapter wants Locus to launch when the user taps "Settings"
-     * on the adapter row in the picker.
+     * on [deviceId]'s row in the picker.
      */
-    @nullable Intent getIntentForSettings();
+    @nullable Intent getIntentForSettings(String deviceId);
 
     /**
-     * Tear down per-pairing state. Called by Locus on unpair / app shutdown.
+     * Tear down per-pairing state for [deviceId]. Called by Locus on unpair / disconnect / app
+     * shutdown, once per bound device (mirrors the [deviceId] of `init` / `parseData`).
      */
-    void shutdown();
+    void shutdown(String deviceId);
 }

--- a/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorWriteChannel.aidl
+++ b/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorWriteChannel.aidl
@@ -15,9 +15,9 @@ import locus.api.android.features.sensorAdapter.parser.AdapterWrite;
 oneway interface ILocusSensorWriteChannel {
 
     /**
-     * Write to the device the adapter is bound for. {@code deviceId} matches the bound
-     * {@code LocusBindContext.deviceId} (and {@code parseData}'s {@code deviceId}); Locus drops the
-     * call when it doesn't match the session.
+     * Write to the device the adapter is bound for. {@code deviceId} matches the {@code deviceId}
+     * the session was opened with at {@code init(...)} (and {@code parseData}'s {@code deviceId});
+     * Locus drops the call when it doesn't match the session.
      */
     void writeData(String deviceId, in List<AdapterWrite> writes);
 }

--- a/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorWriteChannel.aidl
+++ b/locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorWriteChannel.aidl
@@ -1,0 +1,23 @@
+// ILocusSensorWriteChannel.aidl
+package locus.api.android.features.sensorAdapter.parser;
+
+import locus.api.android.features.sensorAdapter.parser.AdapterWrite;
+
+/**
+ * Callback Locus hands the adapter in {@code init(...)} so the adapter can initiate writes to the
+ * device independent of {@code parseData(...)} — e.g. a connect-time handshake, a periodic poll, or
+ * an event-driven command. Complements the reactive {@code SensorValueBatch.writeBacks} return path.
+ *
+ * {@code oneway}: fire-and-forget, never blocks the adapter. Locus drops a write when the session
+ * is closed or the device type's transport is read-only. Provided as null when the transport can't
+ * write (e.g. NET).
+ */
+oneway interface ILocusSensorWriteChannel {
+
+    /**
+     * Write to the device the adapter is bound for. {@code deviceId} matches the bound
+     * {@code LocusBindContext.deviceId} (and {@code parseData}'s {@code deviceId}); Locus drops the
+     * call when it doesn't match the session.
+     */
+    void writeData(String deviceId, in List<AdapterWrite> writes);
+}

--- a/locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/LocusBindContext.kt
+++ b/locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/LocusBindContext.kt
@@ -10,6 +10,7 @@ import kotlinx.parcelize.Parcelize
 /**
  * Payload passed to the adapter's `init(...)`. Carries the running Locus's identification plus
  * the [LocusVariable] refIds it understands; the adapter emits only refIds in [supportedRefIds].
+ * The device the bind is for arrives as the separate `deviceId` / `deviceTypeId` `init` arguments.
  *
  * @property locusApiVersion the [AdapterApi.VERSION] Locus speaks; a mismatch the XML filter let
  *   through is reported via [AdapterApi.INIT_INCOMPATIBLE_API]

--- a/locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt
+++ b/locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt
@@ -7,8 +7,10 @@ package locus.api.android.features.sensorAdapter.parser
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import android.os.RemoteException
 import locus.api.android.features.sensorAdapter.AdapterApi
 import locus.api.android.features.sensorAdapter.LocusBindContext
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Base class for **parser-style** adapter apps — the simpler of the two adapter
@@ -44,41 +46,49 @@ import locus.api.android.features.sensorAdapter.LocusBindContext
  *
  * ```kotlin
  * class MyAdapterService : LocusParserAdapterService() {
- *     override fun init(bindContext: LocusBindContext): Int = AdapterApi.INIT_OK
- *     override fun parseData(
- *         deviceId: String,
- *         deviceTypeId: String,
- *         source: String,
- *         bytes: ByteArray,
- *     ): SensorValueBatch? = …
+ *     override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int =
+ *         AdapterApi.INIT_OK
+ *     override fun parseData(deviceId: String, source: String, bytes: ByteArray): SensorValueBatch? = …
  * }
  * ```
  */
 abstract class LocusParserAdapterService : Service() {
 
+    /**
+     * Per-device write channels Locus handed us at `init`, keyed by `deviceId`. Used by
+     * [writeData]; a dead channel (Locus session gone) evicts itself on the next failed call.
+     */
+    private val writeChannels = ConcurrentHashMap<String, ILocusSensorWriteChannel>()
+
     private val binder = object : ILocusSensorAdapterParser.Stub() {
 
-        override fun init(bindContext: LocusBindContext): Int {
-            return this@LocusParserAdapterService.init(bindContext)
+        override fun init(
+            deviceId: String,
+            deviceTypeId: String,
+            bindContext: LocusBindContext,
+            writeChannel: ILocusSensorWriteChannel?,
+        ): Int {
+            // null for read-only transports; store per device so multi-device adapters address
+            // the right session in writeData
+            writeChannel?.let { writeChannels[deviceId] = it }
+            return this@LocusParserAdapterService.init(deviceId, deviceTypeId, bindContext)
         }
 
         override fun parseData(
             deviceId: String,
-            deviceTypeId: String,
             source: String,
             bytes: ByteArray,
         ): SensorValueBatch? {
-            return this@LocusParserAdapterService.parseData(
-                deviceId, deviceTypeId, source, bytes,
-            )
+            return this@LocusParserAdapterService.parseData(deviceId, source, bytes)
         }
 
-        override fun getIntentForSettings(): Intent? {
-            return this@LocusParserAdapterService.getIntentForSettings()
+        override fun getIntentForSettings(deviceId: String): Intent? {
+            return this@LocusParserAdapterService.getIntentForSettings(deviceId)
         }
 
-        override fun shutdown() {
-            this@LocusParserAdapterService.shutdown()
+        override fun shutdown(deviceId: String) {
+            writeChannels.remove(deviceId)
+            this@LocusParserAdapterService.shutdown(deviceId)
         }
     }
 
@@ -87,10 +97,18 @@ abstract class LocusParserAdapterService : Service() {
     }
 
     /**
-     * Negotiate startup. See [ILocusSensorAdapterParser.init]. Return one of the
-     * [AdapterApi] `INIT_*` constants.
+     * Negotiate startup for one bound device. See [ILocusSensorAdapterParser.init]. Return one of
+     * the [AdapterApi] `INIT_*` constants. Keep a `deviceId → deviceTypeId` mapping here if you
+     * need the type in later [parseData] calls (they carry only `deviceId`).
+     *
+     * The write channel (if the transport is writable) is already stored by the time this runs, so
+     * an adapter may call [writeData] from here for a connect-time handshake.
      */
-    protected abstract fun init(bindContext: LocusBindContext): Int
+    protected abstract fun init(
+        deviceId: String,
+        deviceTypeId: String,
+        bindContext: LocusBindContext,
+    ): Int
 
     /**
      * Parse one inbound data unit — a GATT frame (BT4) or a byte-stream chunk (BT3 / USB / NET).
@@ -99,26 +117,44 @@ abstract class LocusParserAdapterService : Service() {
      */
     protected abstract fun parseData(
         deviceId: String,
-        deviceTypeId: String,
         source: String,
         bytes: ByteArray,
     ): SensorValueBatch?
 
     /**
-     * Optional settings activity intent. See
+     * Initiate a write to [deviceId], independent of [parseData] — for a connect-time handshake, a
+     * periodic poll, or an event-driven command. Complements returning `writeBacks` from a
+     * [parseData] batch (the reactive path). No-op when the device's transport is read-only or its
+     * session has ended.
+     */
+    protected fun writeData(deviceId: String, writes: List<AdapterWrite>) {
+        if (writes.isEmpty()) {
+            return
+        }
+        val channel = writeChannels[deviceId] ?: return
+        try {
+            channel.writeData(deviceId, writes)
+        } catch (_: RemoteException) {
+            // Locus side gone — drop the dead channel
+            writeChannels.remove(deviceId)
+        }
+    }
+
+    /**
+     * Optional settings activity intent for [deviceId]. See
      * [ILocusSensorAdapterParser.getIntentForSettings]. Default implementation returns
      * `null` (no settings UI).
      */
-    protected open fun getIntentForSettings(): Intent? {
+    protected open fun getIntentForSettings(deviceId: String): Intent? {
         return null
     }
 
     /**
-     * Tear down per-pairing state. See [ILocusSensorAdapterParser.shutdown]. Default
-     * implementation is a no-op; override for adapters that hold device handles or
-     * background work.
+     * Tear down per-pairing state for [deviceId]. See [ILocusSensorAdapterParser.shutdown]. The base
+     * class already drops [deviceId]'s write channel before this runs; override to release your own
+     * per-device state (parsers, buffers, handles). Default is a no-op.
      */
-    protected open fun shutdown() {
+    protected open fun shutdown(deviceId: String) {
     }
 
     companion object {

--- a/samples/android-sensor-adapter/src/main/java/com/asamm/locus/api/sample/sensoradapter/HrmAdapterService.kt
+++ b/samples/android-sensor-adapter/src/main/java/com/asamm/locus/api/sample/sensoradapter/HrmAdapterService.kt
@@ -36,25 +36,25 @@ import locus.api.android.features.sensorAdapter.parser.SensorValueBatchBuilder
  */
 class HrmAdapterService : LocusParserAdapterService() {
 
-    override fun init(bindContext: LocusBindContext): Int {
-        // No init-time work — this adapter is stateless across binds. Adapters that
-        // need credentials / runtime permissions / in-app pairing return
-        // AdapterApi.INIT_NEED_USER_ACTION and host the flow in getIntentForSettings().
-        return AdapterApi.INIT_OK
+    override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
+        // No init-time work — this adapter is stateless across binds. The deviceTypeId is validated
+        // once here so parseData (which gets only deviceId) doesn't re-check it. Adapters that need
+        // credentials / runtime permissions / in-app pairing return AdapterApi.INIT_NEED_USER_ACTION
+        // and host the flow in getIntentForSettings().
+        return if (deviceTypeId == DEVICE_TYPE_HRM) {
+            AdapterApi.INIT_OK
+        } else {
+            AdapterApi.INIT_ERROR
+        }
     }
 
     override fun parseData(
         deviceId: String,
-        deviceTypeId: String,
         source: String,
         bytes: ByteArray,
     ): SensorValueBatch? {
-        // Locus only ever calls us with our own declared device type / characteristic, but the
-        // defensive checks document the contract for adapter authors copying this sample. For BT4
-        // `source` is the characteristic UUID.
-        if (deviceTypeId != DEVICE_TYPE_HRM) {
-            return null
-        }
+        // Locus only ever calls us for our declared characteristic, but the check documents the
+        // contract for adapter authors copying this sample. For BT4 `source` is the characteristic UUID.
         if (!source.equals(CHAR_HRM_MEASUREMENT, ignoreCase = true)) {
             return null
         }
@@ -65,12 +65,12 @@ class HrmAdapterService : LocusParserAdapterService() {
     }
 
     /**
-     * Optional. Locus launches this when the user taps "Settings" on the adapter's picker
+     * Optional. Locus launches this when the user taps "Settings" on [deviceId]'s picker
      * row (and in the [AdapterApi.INIT_NEED_USER_ACTION] flow). This sample has no real
      * settings, so it just opens the info screen. Adapters with no settings UI can drop this
      * override entirely — the base class returns `null`.
      */
-    override fun getIntentForSettings(): Intent {
+    override fun getIntentForSettings(deviceId: String): Intent {
         return Intent(this, InfoActivity::class.java)
     }
 

--- a/samples/android-sensor-adapter/src/main/java/com/asamm/locus/api/sample/sensoradapter/NmeaSpeedAdapterService.kt
+++ b/samples/android-sensor-adapter/src/main/java/com/asamm/locus/api/sample/sensoradapter/NmeaSpeedAdapterService.kt
@@ -38,19 +38,21 @@ class NmeaSpeedAdapterService : LocusParserAdapterService() {
      */
     private val lineBuffers = HashMap<String, StringBuilder>()
 
-    override fun init(bindContext: LocusBindContext): Int {
-        return AdapterApi.INIT_OK
+    override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
+        // both device types (BT3 + USB) use the same NMEA parsing; deviceTypeId is validated here
+        // once, so parseData (which gets only deviceId) doesn't re-check it
+        return if (deviceTypeId in DEVICE_TYPES_NMEA_SPEED) {
+            AdapterApi.INIT_OK
+        } else {
+            AdapterApi.INIT_ERROR
+        }
     }
 
     override fun parseData(
         deviceId: String,
-        deviceTypeId: String,
         source: String,
         bytes: ByteArray,
     ): SensorValueBatch? {
-        if (deviceTypeId !in DEVICE_TYPES_NMEA_SPEED) {
-            return null
-        }
         // Append this chunk to the device's buffer and pull out every complete line; the
         // unterminated remainder (if any) stays buffered for the next call.
         val lines = synchronized(lineBuffers) {
@@ -70,9 +72,10 @@ class NmeaSpeedAdapterService : LocusParserAdapterService() {
             .build()
     }
 
-    override fun shutdown() {
+    override fun shutdown(deviceId: String) {
+        // drop only this device's reassembly buffer (the base class already released its write channel)
         synchronized(lineBuffers) {
-            lineBuffers.clear()
+            lineBuffers.remove(deviceId)
         }
     }
 


### PR DESCRIPTION
Adds an adapter-initiated write path and tightens the per-call signatures, folded into the initial v1 contract (so `AdapterApi.VERSION` stays 1 — done before the publish tag).

## Adapter-initiated writes
- New `oneway` `ILocusSensorWriteChannel { writeData(deviceId, List<AdapterWrite>) }` — Locus hands it to the adapter at `init` (null for read-only transports).
- `LocusParserAdapterService` stores it per device and exposes `protected fun writeData(deviceId, writes)`, so an adapter can write **independent of `parseData`**: a connect-time handshake (from `init`), a periodic poll on its own timer, or an event-driven command. Complements the reactive `SensorValueBatch.writeBacks` return path. Self-evicts a dead channel on `RemoteException`; the base class also drops the channel on `shutdown(deviceId)`.

## Session identity at init
- `init(deviceId, deviceTypeId, bindContext, writeChannel)` establishes the device + type once. The per-call methods now carry only `deviceId`: `parseData(deviceId, source, bytes)`, `getIntentForSettings(deviceId)`, `shutdown(deviceId)`. Adapters keep a `deviceId → deviceTypeId` map if they need the type. `LocusBindContext` reverts to Locus-identity only.
- Samples (`HrmAdapterService`, `NmeaSpeedAdapterService`) validate `deviceTypeId` at `init`; `shutdown(deviceId)` releases just that device's state.

## Docs
`aidl-contract.md` (init / parseData / getIntentForSettings / shutdown examples, both write paths) and the guide README minimal adapter updated to the refined signatures.

## Consumed by
locus-core PR #811 (`feature/adapter-writeback`) — the `AdapterBridge` runtime that drives this channel.

## Test plan
- [x] `:samples:android-sensor-adapter:assembleDebug` green; published to mavenLocal; locus-core compiles against it.
- [ ] On-device write-back (e.g. EBikeLocus trigger write) via the published Beta — can't be exercised by either maintainer locally.