### PR TITLE
Adapter-apps docs: trim + add step-by-step how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
     <a href="#structure">Structure</a> | 
     <a href="#what-does-it-do">What does it do?</a> | 
     <a href="#what-it-isnt">What it isn't</a> | 
-    <a href="#quick-start">Quick start</a>
+    <a href="#quick-start">Quick start</a> | 
+    <a href="#sensor-adapter-apps">Sensor adapter apps</a>
 </p>
 
 # Locus API
@@ -63,6 +64,16 @@ dependencies {
 ```
 
 Check for sample use-cases in Locus API - Android sample project.
+
+## Sensor adapter apps
+
+Expose a sensor (real or virtual) to Locus Map over an AIDL contract. Locus owns the BT3 / BT4 /
+USB transport; your adapter declares its device types and parses bytes — values land in Locus's
+dashboards, track recording, and audio coach like any built-in sensor.
+
+- **Start here:** [`docs/android/guides/adapter-apps/how-to.md`](docs/android/guides/adapter-apps/how-to.md) — six-step build from empty project to paired sensor.
+- **Working sample:** [`samples/android-sensor-adapter`](samples/android-sensor-adapter) — BT4 HRM + BT3/USB NMEA GNSS.
+- **Reference:** [`docs/android/guides/adapter-apps/`](docs/android/guides/adapter-apps/) (manifest schema, AIDL contract, curated refIds).
 
 ### Proguard
 

--- a/docs/android/guides/adapter-apps/README.md
+++ b/docs/android/guides/adapter-apps/README.md
@@ -7,7 +7,7 @@ Locus's dashboards / track recording / audio coach like any built-in sensor.
 | Topic | Doc |
 |---|---|
 | **Step-by-step (start here)** | [`how-to.md`](how-to.md) |
-| **Working sample app** | [`samples/android-sensor-adapter`](../../../samples/android-sensor-adapter) — BT4 HRM + BT3/USB NMEA GNSS, with manifests, parsers, and pair-in-Locus steps |
+| **Working sample app** | [`samples/android-sensor-adapter`](../../../../samples/android-sensor-adapter) — BT4 HRM + BT3/USB NMEA GNSS, with manifests, parsers, and pair-in-Locus steps |
 | Manifest XML schema | [`manifest-schema.md`](manifest-schema.md) |
 | AIDL service contract | [`aidl-contract.md`](aidl-contract.md) |
 | Curated refIds you can write to | [`../../reference/locus-variables.md`](../../reference/locus-variables.md) |
@@ -15,7 +15,7 @@ Locus's dashboards / track recording / audio coach like any built-in sensor.
 
 ## Versioning
 
-The contract version is [`AdapterApi.VERSION`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/AdapterApi.kt),
+The contract version is [`AdapterApi.VERSION`](../../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/AdapterApi.kt),
 bumped only on breaking AIDL or manifest changes. Adapters declare the version they target as
 `<adapter apiVersion="…">`; Locus filters incompatible adapters out of the picker pre-bind. A
 finer-grained runtime mismatch can be reported by returning `AdapterApi.INIT_INCOMPATIBLE_API`

--- a/docs/android/guides/adapter-apps/README.md
+++ b/docs/android/guides/adapter-apps/README.md
@@ -1,99 +1,22 @@
-# Building a Locus parser adapter app
+# Locus sensor adapter apps
 
-Adapter apps let your Android app expose a sensor (real or virtual) to Locus Map.
-Locus owns the transport — Bluetooth Classic (BT3 / SPP), Bluetooth LE (BT4 / GATT),
-or USB-serial — and your adapter writes only the byte parser and declares which Locus
-Variables it produces. The data lands in Locus's dashboards / track recording / audio
-coach exactly like a built-in sensor.
-
-Your adapter declares one or more device types, each producing values for a curated set
-of built-in Locus Variables over its transport. For BT4, Locus drives the GATT lifecycle
-and hands you each characteristic's bytes; for stream transports (BT3 / USB) it hands you
-raw stream bytes. Locus handles discovery, scanning / device selection, the connection
-lifecycle, and routing parsed values into its dashboards.
-
-## TL;DR
-
-1. Add the `locus-api-android` dependency (JitPack):
-   `implementation("com.github.asamm.locus-api:locus-api-android:<version>")`.
-2. Subclass [`LocusParserAdapterService`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
-   and implement two methods: `init` and `parseData`.
-3. Declare the service in your `AndroidManifest.xml` with the
-   `locus.api.android.ACTION_SENSOR_ADAPTER_PARSER` intent-filter action and
-   the `com.asamm.locus.permission.SENSOR_ADAPTER` permission (Locus declares
-   it; your adapter requires it). Set `android:icon` on the service for the
-   picker icon.
-4. Add a `<meta-data>` pointing to a `res/xml/locus_adapter.xml` device-type
-   catalog with adapter-level metadata (apiVersion, id, displayName) on the
-   root and one `<deviceType>` per kind of hardware (see
-   [`manifest-schema.md`](manifest-schema.md)). Locus reads it all without
-   binding the service.
-5. Install both Locus Map and your adapter on the same device. Open Locus's
-   sensor picker; your adapter's device types appear under "External adapters."
-
-## Walkthroughs
+Adapter apps expose a sensor (real or virtual) to Locus Map. Locus owns the transport — BT3 / SPP,
+BT4 / GATT, or USB-serial — your adapter declares its device types and parses bytes. Values land in
+Locus's dashboards / track recording / audio coach like any built-in sensor.
 
 | Topic | Doc |
 |---|---|
-| **Working sample app (start here)** | [`samples/android-sensor-adapter`](../../../samples/android-sensor-adapter) — two complete services: a BT4 HRM and a BT3 + USB NMEA-speed GNSS, with manifests, parsers, and build/pair steps in its own README |
-| Manifest XML schema + sample | [`manifest-schema.md`](manifest-schema.md) |
+| **Step-by-step (start here)** | [`how-to.md`](how-to.md) |
+| **Working sample app** | [`samples/android-sensor-adapter`](../../../samples/android-sensor-adapter) — BT4 HRM + BT3/USB NMEA GNSS, with manifests, parsers, and pair-in-Locus steps |
+| Manifest XML schema | [`manifest-schema.md`](manifest-schema.md) |
 | AIDL service contract | [`aidl-contract.md`](aidl-contract.md) |
-| Curated refIds your adapter can write to | [`../../reference/locus-variables.md`](../../reference/locus-variables.md) |
-| Annotated sample manifest XML | [`sample-manifest.xml`](sample-manifest.xml) |
-
-## Minimal adapter (BT4)
-
-```kotlin
-class BoschEBikeAdapterService : LocusParserAdapterService() {
-
-    override fun init(deviceId: String, deviceTypeId: String, bindContext: LocusBindContext): Int {
-        // deviceTypeId picks the protocol for this device; keep a deviceId -> deviceTypeId map if you
-        // need it in parseData. bindContext tells you which refIds Locus understands + its version —
-        // bail with INIT_INCOMPATIBLE_API on a finer-grained mismatch the XML apiVersion filter missed.
-        return AdapterApi.INIT_OK
-    }
-
-    override fun parseData(
-        deviceId: String,
-        source: String,
-        bytes: ByteArray,
-    ): SensorValueBatch? {
-        // Locus owns scanning + transport lifecycle; your parser only handles bytes.
-        // `source` is the characteristic UUID for BT4, empty for stream transports.
-        // Owns frame-reassembly state. Return null when bytes were consumed
-        // without producing values (partial frame).
-        val decoded = BoschLiveDataDecoder.decode(bytes) ?: return null
-        return SensorValueBatchBuilder(System.currentTimeMillis())
-            .put(LocusVariable.HeartRate, decoded.heartRate)
-            .put(LocusVariable.Cadence, decoded.cadence)
-            .put(LocusVariable.Power, decoded.power)
-            .put(LocusVariable.BicycleBattery, decoded.batteryPercent)
-            .build()
-    }
-}
-```
-
-The `LocusVariable.X` constants are typed: writing a `Float` to a
-`LocusVariable<Int>` slot is a compile error, not a runtime surprise.
-
-The session's `deviceTypeId` (from `init`) matches an `<deviceType id="...">` from your manifest
-XML — adapters that handle multiple device types (e.g. Bosch + Shimano under one adapter) keep a
-`deviceId → deviceTypeId` map and switch on it for protocol-specific parsing.
+| Curated refIds you can write to | [`../../reference/locus-variables.md`](../../reference/locus-variables.md) |
+| Annotated sample manifest | [`sample-manifest.xml`](sample-manifest.xml) |
 
 ## Versioning
 
-The contract version is [`AdapterApi.VERSION`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/AdapterApi.kt).
-Bumped only when AIDL surface changes are backward-incompatible. Adapters
-declare the version they're built against as `<adapter apiVersion="…">` in
-their manifest XML; Locus filters incompatible adapters out of the picker
-before any bind.
-
-Parcelable payloads (`LocusBindContext`, `SensorValueBatch`,
-`AdapterWrite`) are frozen for a given `AdapterApi.VERSION` — `@Parcelize`
-reads fields positionally and has no length prefix, so adding fields in place
-would break adapters built against the old shape. New payload fields ship with
-a `VERSION` bump.
-
-If a finer-grained version mismatch slips past the XML filter at runtime, the
-adapter's `init()` returns `AdapterApi.INIT_INCOMPATIBLE_API` and Locus skips
-the session with a user-facing message.
+The contract version is [`AdapterApi.VERSION`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/AdapterApi.kt),
+bumped only on breaking AIDL or manifest changes. Adapters declare the version they target as
+`<adapter apiVersion="…">`; Locus filters incompatible adapters out of the picker pre-bind. A
+finer-grained runtime mismatch can be reported by returning `AdapterApi.INIT_INCOMPATIBLE_API`
+from `init`.

--- a/docs/android/guides/adapter-apps/aidl-contract.md
+++ b/docs/android/guides/adapter-apps/aidl-contract.md
@@ -1,13 +1,10 @@
 # Parser-adapter AIDL contract
 
-The contract between Locus and a parser-style adapter app is the
+The bound-service interface
 [`ILocusSensorAdapterParser`](../../../locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl)
-bound service interface plus the Parcelable payload classes in the same
-package. The [`LocusParserAdapterService`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
-base class wires the AIDL stub to abstract Kotlin methods so you don't write
-any binder code.
-
-This page walks the surface call-by-call.
+plus the Parcelable payloads in the same package. Subclass
+[`LocusParserAdapterService`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
+and you don't write any binder code — it wires the AIDL stub to abstract Kotlin methods.
 
 ## Bind lifecycle
 
@@ -36,13 +33,9 @@ This page walks the surface call-by-call.
 > parsed and skipped. v1 ships BT3 / BT4 / USB (read **and** write); NET lands later with no
 > contract change. Build against BT3 / BT4 / USB for now.
 
-Note: there's no `getAvailableDevices()` AIDL call. Locus owns the device list
-— it scans BLE for new pairings and tracks paired peers in its own
-pairing-persistence layer.
-
-There's also no `getDescriptor()` or `getApiVersion()` AIDL call — all static
-metadata is declared in the manifest XML so the picker can be populated
-without binding any adapter.
+There are no `getAvailableDevices()` / `getDescriptor()` / `getApiVersion()` AIDL calls. Locus
+owns the device list and persistence; all static metadata is in the manifest XML so the picker is
+populated pre-bind.
 
 ## Methods
 
@@ -127,38 +120,10 @@ shouldn't wait for inbound data. No-op if the transport is read-only or the sess
 
 ### `getIntentForSettings`
 
-Returns an `Intent` Locus launches when the user taps "Settings" on
-`deviceId`'s picker row, or `null` for adapters with no settings UI.
-
-Used in the `INIT_NEED_USER_ACTION` flow: if your adapter needs credentials /
-permissions / in-app pairing before it can work, return that flow's Activity
-intent here. Locus relaunches `init` after the Activity returns.
-
-**Locus-side hardening** (notes for the locus-core implementer, not the
-adapter author): the returned `Intent` crosses the binder fully serialized —
-component, action, data URI, extras, flags. Before launching, Locus must
-re-anchor it to the adapter's package and strip cross-package grants:
-
-```kotlin
-val intent = adapter.getIntentForSettings(deviceId) ?: return
-intent.setPackage(adapterPackageName)        // pin to the adapter's package
-intent.component?.let {
-    require(it.packageName == adapterPackageName)
-}
-intent.flags = intent.flags and
-    Intent.FLAG_GRANT_READ_URI_PERMISSION.inv() and
-    Intent.FLAG_GRANT_WRITE_URI_PERMISSION.inv() and
-    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION.inv() and
-    Intent.FLAG_GRANT_PREFIX_URI_PERMISSION.inv()
-startActivity(intent)
-```
-
-Without this, a malicious or buggy adapter could return an Intent targeting a
-different package's exported activity, or grant itself URI permissions on
-`content://` data it doesn't own.
-
-The base class's default returns `null`. Override only when you have a UI to
-host.
+Return an `Intent` Locus launches when the user taps "Settings" on `deviceId`'s picker row, or
+`null` if your adapter has no settings UI. Also used in the `INIT_NEED_USER_ACTION` flow — if the
+adapter needs credentials / permissions / in-app pairing first, return that Activity's intent;
+Locus relaunches `init` after it returns. Base class default: `null`.
 
 ### `shutdown`
 
@@ -168,8 +133,6 @@ override fun shutdown(deviceId: String) {
 }
 ```
 
-Called once per bound device when the user unpairs, the device disconnects, or Locus shuts down —
-`deviceId` matches `init` / `parseData`, so a multi-device adapter releases just that device's
-state. The base class drops that device's write channel before this runs.
-
-The base class's default is a no-op. Override only for adapters that hold per-device resources.
+Called once per bound device on unpair / disconnect / app shutdown. The base class drops that
+device's write channel before this runs; default is otherwise a no-op. Override to release your
+own per-device state (buffers, timers, handles).

--- a/docs/android/guides/adapter-apps/aidl-contract.md
+++ b/docs/android/guides/adapter-apps/aidl-contract.md
@@ -1,9 +1,9 @@
 # Parser-adapter AIDL contract
 
 The bound-service interface
-[`ILocusSensorAdapterParser`](../../../locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl)
+[`ILocusSensorAdapterParser`](../../../../locus-api-android/src/main/aidl/locus/api/android/features/sensorAdapter/parser/ILocusSensorAdapterParser.aidl)
 plus the Parcelable payloads in the same package. Subclass
-[`LocusParserAdapterService`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
+[`LocusParserAdapterService`](../../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
 and you don't write any binder code — it wires the AIDL stub to abstract Kotlin methods.
 
 ## Bind lifecycle
@@ -78,7 +78,7 @@ override fun parseData(
 protocol. Return either:
 
 - A
-  [`SensorValueBatch`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/SensorValueBatch.kt)
+  [`SensorValueBatch`](../../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/SensorValueBatch.kt)
   containing parsed `(refId → value)` pairs, optionally with write-backs.
 - `null` to indicate the data was consumed without producing values
   (e.g. partial frame buffered for reassembly).
@@ -88,7 +88,7 @@ your parser should be re-entrant per `deviceId` or hold a `synchronized`
 section.
 
 Build the batch via
-[`SensorValueBatchBuilder`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/SensorValueBatchBuilder.kt):
+[`SensorValueBatchBuilder`](../../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/SensorValueBatchBuilder.kt):
 
 ```kotlin
 SensorValueBatchBuilder(timestamp = System.currentTimeMillis())

--- a/docs/android/guides/adapter-apps/how-to.md
+++ b/docs/android/guides/adapter-apps/how-to.md
@@ -1,0 +1,110 @@
+# How to build a Locus sensor adapter
+
+Six steps from empty Android project to your adapter visible in Locus's picker. The example
+targets a BT4 heart-rate monitor; BT3 and USB differ only in the manifest XML (step 3).
+
+## 1. Add the dependency
+
+In `build.gradle.kts`:
+
+```kotlin
+repositories {
+    maven("https://jitpack.io")
+}
+
+dependencies {
+    implementation("com.github.asamm.locus-api:locus-api-android:0.10.0")
+}
+```
+
+## 2. Declare the service in `AndroidManifest.xml`
+
+```xml
+<service
+    android:name=".MyAdapterService"
+    android:exported="true"
+    android:icon="@drawable/ic_my_adapter"
+    android:permission="com.asamm.locus.permission.SENSOR_ADAPTER">
+
+    <intent-filter>
+        <action android:name="locus.api.android.ACTION_SENSOR_ADAPTER_PARSER" />
+    </intent-filter>
+
+    <meta-data
+        android:name="locus.api.android.SENSOR_ADAPTER"
+        android:resource="@xml/locus_adapter" />
+</service>
+```
+
+The action / permission / meta-data key are also constants on `LocusParserAdapterService`
+(`ACTION_BIND`, `PERMISSION`, `META_DATA_KEY`).
+
+## 3. Declare your device types in `res/xml/locus_adapter.xml`
+
+```xml
+<adapter
+    apiVersion="1"
+    id="com.example.myadapter/MyAdapter"
+    displayName="My Adapter">
+
+    <deviceType
+        id="my-hrm"
+        connectionType="BT4"
+        displayName="My HRM">
+
+        <refId variable="SENSOR_HEART_RATE" />
+        <characteristic uuid="2a37" mode="NOTIFY" />
+    </deviceType>
+</adapter>
+```
+
+- **BT3** — `connectionType="BT3"`, no `<characteristic>`. Stream of bytes.
+- **USB** — `connectionType="USB"` + `vendorId="…"` `productId="…"` (decimal or `0x`-hex).
+- Full attribute list: [`manifest-schema.md`](manifest-schema.md). Curated refIds: [`locus-variables.md`](../../reference/locus-variables.md).
+
+## 4. Implement the service
+
+```kotlin
+class MyAdapterService : LocusParserAdapterService() {
+
+    override fun init(
+        deviceId: String,
+        deviceTypeId: String,
+        bindContext: LocusBindContext,
+    ): Int {
+        return AdapterApi.INIT_OK
+    }
+
+    override fun parseData(
+        deviceId: String,
+        source: String,
+        bytes: ByteArray,
+    ): SensorValueBatch? {
+        val hr = decodeHeartRate(bytes) ?: return null
+        return SensorValueBatchBuilder(System.currentTimeMillis())
+            .put(LocusVariable.HeartRate, hr)
+            .build()
+    }
+}
+```
+
+- `deviceId` is the paired peer's stable id; `source` is the BT4 characteristic UUID, or `""` for
+  stream transports.
+- Return `null` when bytes are consumed without producing a value (partial frame).
+- Full method semantics: [`aidl-contract.md`](aidl-contract.md).
+
+## 5. Install both apps
+
+Install Locus Map and your adapter app on the same device.
+
+## 6. Pair in Locus
+
+Open Locus's sensor picker → **External adapters** → your device type appears. Tap, scan, pair.
+Values land in Locus's dashboards, track recording, and audio coach like any built-in sensor.
+
+## What next
+
+- Multiple device types under one app, multi-transport, write-backs, settings UI:
+  [the sample app](../../../samples/android-sensor-adapter).
+- Adapter-initiated writes (handshake / poll / event) via `writeData(deviceId, …)`:
+  [`aidl-contract.md`](aidl-contract.md#write-backs).

--- a/docs/android/guides/adapter-apps/how-to.md
+++ b/docs/android/guides/adapter-apps/how-to.md
@@ -60,7 +60,8 @@ The action / permission / meta-data key are also constants on `LocusParserAdapte
 
 - **BT3** — `connectionType="BT3"`, no `<characteristic>`. Stream of bytes.
 - **USB** — `connectionType="USB"` + `vendorId="…"` `productId="…"` (decimal or `0x`-hex).
-- Full attribute list: [`manifest-schema.md`](manifest-schema.md). Curated refIds: [`locus-variables.md`](../../reference/locus-variables.md).
+- Full attribute list: [`manifest-schema.md`](manifest-schema.md).
+- Curated refIds: [`locus-variables.md`](../../reference/locus-variables.md).
 
 ## 4. Implement the service
 
@@ -105,6 +106,6 @@ Values land in Locus's dashboards, track recording, and audio coach like any bui
 ## What next
 
 - Multiple device types under one app, multi-transport, write-backs, settings UI:
-  [the sample app](../../../samples/android-sensor-adapter).
+  [the sample app](../../../../samples/android-sensor-adapter).
 - Adapter-initiated writes (handshake / poll / event) via `writeData(deviceId, …)`:
   [`aidl-contract.md`](aidl-contract.md#write-backs).

--- a/docs/android/guides/adapter-apps/manifest-schema.md
+++ b/docs/android/guides/adapter-apps/manifest-schema.md
@@ -1,13 +1,10 @@
 # Adapter manifest schema
 
-Each adapter app declares its presence to Locus via two pieces of XML:
+Two pieces of XML:
 
-1. A `<service>` entry in `AndroidManifest.xml` with the right intent-filter and
-   permission gate.
-2. A `<meta-data>` on that service pointing to a `res/xml/locus_adapter.xml`
-   resource describing the adapter's **device-type catalog** — the kinds of
-   hardware it knows how to handle. Locus reads this XML without binding the
-   service, so the picker can show device types before the user commits.
+1. A `<service>` entry in `AndroidManifest.xml` (intent-filter + permission gate).
+2. `res/xml/locus_adapter.xml` — the adapter's **device-type catalog**, pointed at by `<meta-data>`
+   on the service. Locus reads it without binding, so the picker is populated pre-bind.
 
 ## `AndroidManifest.xml`
 
@@ -30,20 +27,16 @@ Each adapter app declares its presence to Locus via two pieces of XML:
 </application>
 ```
 
-Required attributes:
-
 | Attribute / element | Why |
 |---|---|
-| `android:exported="true"` | Locus is a separate package — the service must be reachable across process boundaries. |
-| `android:permission="com.asamm.locus.permission.SENSOR_ADAPTER"` | Only Locus (which holds this permission) can bind. Locus declares the permission with `protectionLevel="normal"` so third-party adapters can require it without code-signing constraints. |
-| `<action android:name="locus.api.android.ACTION_SENSOR_ADAPTER_PARSER" />` | Discovery key — Locus queries `PackageManager.queryIntentServices` on this action to find adapters. |
-| `<meta-data android:name="locus.api.android.SENSOR_ADAPTER" … />` | Points Locus at the device-type catalog XML below. |
-| `android:icon` (optional) | Adapter icon shown in the picker. Locus loads it via `PackageManager.getServiceInfo(...).loadIcon(pm)` — standard Android drawable resource, no bytes over IPC. Falls back to the application icon when omitted. |
+| `android:exported="true"` | Locus is a separate package; the service must be reachable cross-process. |
+| `android:permission="com.asamm.locus.permission.SENSOR_ADAPTER"` | Only Locus (which holds this permission) can bind. |
+| `<action android:name="locus.api.android.ACTION_SENSOR_ADAPTER_PARSER" />` | Discovery key — Locus queries `queryIntentServices` on this action. |
+| `<meta-data android:name="locus.api.android.SENSOR_ADAPTER" … />` | Points at the device-type catalog XML. |
+| `android:icon` (optional) | Picker icon; falls back to the application icon. |
 
-The action / meta-data key / permission constants are also exposed on
-[`LocusParserAdapterService`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/parser/LocusParserAdapterService.kt)
-(`ACTION_BIND`, `META_DATA_KEY`, `PERMISSION`) so you can reference them from
-code rather than typing the strings.
+The action, meta-data key, and permission are also constants on `LocusParserAdapterService`
+(`ACTION_BIND`, `META_DATA_KEY`, `PERMISSION`).
 
 ## `res/xml/locus_adapter.xml`
 
@@ -77,41 +70,32 @@ code rather than typing the strings.
 </adapter>
 ```
 
-The `<adapter>` root carries **all static metadata Locus needs to populate the
-picker** — Locus never binds the service just to read this. Bind happens only
-when the user starts a sensor session.
-
 ### `<adapter>` attributes
 
 | Attribute | Required | Notes |
 |---|---|---|
-| `apiVersion` | yes | The `AdapterApi.VERSION` value the adapter is built against. Locus rejects adapters whose `apiVersion` it can't speak — entirely pre-bind, so incompatible adapters never appear in the picker. Bumped on any breaking change to either the AIDL surface or the manifest XML format; the two evolve together. |
+| `apiVersion` | yes | The `AdapterApi.VERSION` the adapter is built against. Mismatched adapters are filtered out of the picker pre-bind. Bumped on breaking AIDL or XML changes. |
 | `id` | yes | Stable adapter identifier. Convention: `{packageName}/{ServiceClassName}`. |
-| `displayName` | yes | User-visible adapter name. Use `@string/...` for localization. |
+| `displayName` | yes | User-visible name. Use `@string/...` for localization. |
 
 ### `<deviceType>` element
 
-One per **kind** of hardware. Two physical Bosch eBikes paired to the same
-adapter share one `<deviceType id="bosch-ldi">` entry and surface at runtime
-as two separately-paired peers in Locus (each with its own BLE MAC, both
-parsed via the same protocol declared here). Locus tracks per-peer pairing
-on its own side; the adapter only learns about a peer via the `deviceId`
-parameter on each `parseData(...)` call.
+One per **kind** of hardware. Multiple physical units share one `<deviceType>` and surface as
+separately-paired peers; the adapter learns each peer's id only via the `deviceId` parameter on
+`init` / `parseData`.
 
 | Attribute | Required | Notes |
 |---|---|---|
-| `id` | yes | Stable type identifier. Locus passes this back to the adapter as the `deviceTypeId` parameter on every `parseData` call. |
-| `displayName` | yes | User-visible type name shown in the picker pre-bind. |
-| `icon` | no | Per-type picker icon — an `@drawable/...` resource in your adapter package. Locus loads it from your resources (no bytes over IPC). Falls back to the service/app icon (`android:icon`) when omitted, so multi-type adapters can give each hardware kind its own glyph. |
-| `connectionType` | yes | The transport Locus drives for this device type: `BT3` (Bluetooth Classic SPP stream), `BT4` (GATT — uses `<characteristic>` children), `USB` (USB-serial stream — see USB attributes below). `NET` (read-only TCP stream) is **reserved — declared in the API enum but not yet handled by Locus**, so a `NET` device type is currently parsed and skipped; don't ship one yet. Stream transports declare no `<characteristic>`. |
-| `scanFilter` | no | BLE name prefix Locus uses during pairing scans. Omit for scan-by-service-UUID only. |
+| `id` | yes | Stable type identifier. Locus passes this back as `deviceTypeId` to `init`. |
+| `displayName` | yes | User-visible name shown in the picker pre-bind. |
+| `icon` | no | Per-type picker icon (`@drawable/...`). Falls back to the service/app icon when omitted. |
+| `connectionType` | yes | `BT3` (SPP stream), `BT4` (GATT — uses `<characteristic>` children), or `USB` (serial — see USB attributes below). `NET` is reserved in the enum but not driven yet; a `NET` device type is parsed and skipped. |
+| `scanFilter` | no | BLE name prefix for pairing scans. Omit for scan-by-service-UUID only. |
 
 ### `<refId>` element (child of `<deviceType>`)
 
-Lists the [`LocusVariable`](../../reference/locus-variables.md) refIds devices
-of this type can produce. Use the symbolic name; Locus resolves it to the
-integer refId. Adapter-side writes for refIds outside this declared set are
-dropped on Locus's side.
+Lists the [`LocusVariable`](../../reference/locus-variables.md) refIds this device type produces.
+Use the symbolic name (`SENSOR_HEART_RATE`, …); writes for refIds outside this set are dropped.
 
 ### `<characteristic>` element (child of `<deviceType>`, BT4 only)
 
@@ -125,53 +109,24 @@ Omit `<characteristic>` for non-BT4 device types.
 
 ### USB attributes (on `<deviceType connectionType="USB">`)
 
-USB-serial device types carry their identification and serial parameters as attributes on the
-`<deviceType>` element itself (no child element):
+Carried as attributes on `<deviceType>` itself — no child element.
 
 | Attribute | Required | Notes |
 |---|---|---|
-| `vendorId` | yes | USB vendor id (16-bit, `0..65535`). Locus feeds it to its serial prober as a CDC-ACM device so an arbitrary receiver is recognised. Decimal or `0x`-hex. |
-| `productId` | yes | USB product id (16-bit). Decimal or `0x`-hex. |
-| `baudRate` | no | Serial baud rate. Defaults to the GNSS-typical `4800` when omitted. |
-| `dataBits` | no | Data bits (5–8). Defaults to `8`. |
-| `stopBits` | no | Stop bits (`1`, `2`, or `3` for 1.5). Defaults to `1`. |
-| `parity` | no | Parity (`0` none, `1` odd, `2` even, `3` mark, `4` space). Defaults to `0` (none). |
+| `vendorId` | yes | USB vendor id (16-bit, `0..65535`). Decimal or `0x`-hex. Fed to Locus's CDC-ACM serial prober. |
+| `productId` | yes | USB product id (16-bit). |
+| `baudRate` | no | Defaults to `4800` (GNSS-typical). |
+| `dataBits` | no | 5–8. Defaults to `8`. |
+| `stopBits` | no | `1`, `2`, or `3` (= 1.5). Defaults to `1`. |
+| `parity` | no | `0` none, `1` odd, `2` even, `3` mark, `4` space. Defaults to `0`. |
 
-A `connectionType="USB"` device type missing `vendorId` / `productId` (or with an out-of-range
-value) is dropped with a warning. Locus owns the USB connection and permission prompt; the adapter
-only decodes the bytes — the adapter app needs no USB host permissions of its own.
-
-## Runtime: from device types to paired peers
-
-Locus's flow:
-
-1. Discover adapters via `PackageManager.queryIntentServices` filtered by the
-   `locus.api.android.ACTION_SENSOR_ADAPTER_PARSER` action.
-2. Parse each adapter's `res/xml/locus_adapter.xml` (id / displayName /
-   apiVersion / device-type list) and pull the service icon via
-   `loadIcon(pm)` — no service bind. Each `<deviceType icon>` drawable is
-   loaded from the adapter's resources at the same time.
-3. Show the device-type list in the picker (one row per `<deviceType>` across
-   all discovered adapters), each row using its `<deviceType icon>` when set,
-   else the adapter's service/app icon.
-4. User taps a device type → Locus runs a BLE scan using that type's
-   `scanFilter` (BT4 device types) → user picks a BLE peer.
-5. Locus persists pairing keyed on `(adapterId, deviceId)`, binds the adapter,
-   subscribes to the type's `<characteristic>` declarations, and routes every
-   inbound unit to `parseData(deviceId, deviceTypeId, source, bytes)` (`source` = characteristic
-   UUID for BT4, empty for stream transports).
-
-So XML covers the **type catalog** (static, pre-bind, no IPC). AIDL covers
-**byte-frame parsing** at runtime. Locus owns peer discovery and pairing
-persistence — the adapter never enumerates devices.
+A USB device type missing or out-of-range on `vendorId` / `productId` is dropped with a warning.
+Locus owns the connection and permission prompt; the adapter app needs no USB host permissions.
 
 ## Schema evolution
 
-Add new optional attributes / elements freely — Locus's parser ignores unknown
-nodes by design, so an adapter manifest written against a newer locus-api still
-binds against an older Locus (the new fields just have no effect there).
-
-Breaking changes ship under a new `AdapterApi.VERSION`.
+Add new optional attributes/elements freely — unknown nodes are ignored. Breaking changes ship
+under a new `AdapterApi.VERSION`.
 
 ## See also
 

--- a/docs/android/guides/adapter-apps/manifest-schema.md
+++ b/docs/android/guides/adapter-apps/manifest-schema.md
@@ -35,8 +35,8 @@ Two pieces of XML:
 | `<meta-data android:name="locus.api.android.SENSOR_ADAPTER" … />` | Points at the device-type catalog XML. |
 | `android:icon` (optional) | Picker icon; falls back to the application icon. |
 
-The action, meta-data key, and permission are also constants on `LocusParserAdapterService`
-(`ACTION_BIND`, `META_DATA_KEY`, `PERMISSION`).
+The action, permission, and meta-data key are also constants on `LocusParserAdapterService`
+(`ACTION_BIND`, `PERMISSION`, `META_DATA_KEY`).
 
 ## `res/xml/locus_adapter.xml`
 

--- a/docs/android/reference/locus-variables.md
+++ b/docs/android/reference/locus-variables.md
@@ -1,17 +1,13 @@
 # LocusVariable — curated refIds
 
-The Variables an adapter app can write to. Each maps to a built-in `Variable<T>` on the
-Locus-core side (same refId, same `T`).
-
-Defined in
-[`LocusVariable.kt`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/LocusVariable.kt).
-Reference them in code via the typed `LocusVariable` constants, and in your manifest XML
-via the matching `variable` name (`<refId variable="SENSOR_HEART_RATE" />`). The
-`LocusVariable` constructor is private — you use the listed constants, you can't invent
-refIds:
+The Variables an adapter app can write to. Defined in
+[`LocusVariable.kt`](../../../locus-api-android/src/main/java/locus/api/android/features/sensorAdapter/LocusVariable.kt);
+referenced in code via the typed `LocusVariable` constants and in the manifest XML by the matching
+`variable` name (`<refId variable="SENSOR_HEART_RATE" />`). The constructor is private — you use
+the listed constants, you can't invent refIds.
 
 ```kotlin
-batch.put(LocusVariable.HeartRate, 120)   // ✓ typed: an Int slot rejects a Float at compile time
+batch.put(LocusVariable.HeartRate, 120)   // typed: an Int slot rejects a Float at compile time
 ```
 
 | Kotlin constant | Manifest `variable` | refId | Type | Unit / Range | Notes |


### PR DESCRIPTION
Tightens the adapter-apps developer docs (short / direct / no beauty) and adds the six-step
how-to you flagged. Net +191 / −233; one new file (`how-to.md`), no code changes.

## New
- **[`how-to.md`](docs/android/guides/adapter-apps/how-to.md)** — six concrete steps from empty Android project to paired sensor in Locus (dependency → service manifest → `res/xml/locus_adapter.xml` → `init`/`parseData` → install → pair). Linked first from the guide index and from the main repo README's new "Sensor adapter apps" section, so the guide is reachable from the repo root.

## Trimmed
- **Guide README** 99 → 22 lines: dropped the duplicated TL;DR + minimal-adapter snippet (covered by `how-to.md`), kept a tight index + short versioning note.
- **aidl-contract** 175 → 138: removed the "Locus-side hardening" code block (locus-core implementer notes, not adapter-author content), compressed the bind-lifecycle prologue and the `getIntentForSettings` / `shutdown` sections.
- **manifest-schema** 180 → 135: tightened the required-attributes "Why" column, the `<adapter>` / `<deviceType>` notes, and the USB-attributes intro; dropped the "Runtime: from device types to paired peers" duplicate of the AIDL bind lifecycle.
- **locus-variables** 42 → 38: compressed the intro.

## Main README
A short "Sensor adapter apps" section + nav link → `how-to.md`, sample, and reference guide.

This is "starting with precise docs in API" — more (e.g. step-by-steps for write-backs, multi-device adapters, settings UI) can land on top.