### PR TITLE
Improve default LineStyle and correct README docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-03
+### Changed
+- `LineStyle` defaults — `colorBase` is now a slightly transparent blue (`#b30000ff`) and `width` is `6.0f` (was opaque black / `1.0f`)
+
 ## [0.9.73] - 2026-05-18
 ### Fixed
 - `NullPointerException` in `FieldNotesHelper.createItems` when reading `TrackableLog` records with NULL string columns (Locus Map issue #734)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2026-06-03
+## [0.10.1] - 2026-06-03
 ### Changed
 - `LineStyle` defaults — `colorBase` is now a slightly transparent blue (`#b30000ff`) and `width` is `6.0f` (was opaque black / `1.0f`)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ GRADLE_NEXUS_STAGING = 0.30.0
 LOCUS_LOGGER = 2.2
 
 # Version
-API_CODE = 122
-API_VERSION = 0.10.0
+API_CODE = 123
+API_VERSION = 0.10.1
 
 # ANDROID SUPPORT LIBS
 # https://developer.android.com/topic/libraries/support-library/revisions.html

--- a/locus-api-core/src/main/java/locus/api/objects/styles/LineStyle.kt
+++ b/locus-api-core/src/main/java/locus/api/objects/styles/LineStyle.kt
@@ -196,7 +196,7 @@ class LineStyle : Storable() {
         // black color
         private const val COLOR_BLACK = -0x1000000
         // Locus Map default line color — slightly transparent blue (#b30000ff)
-        private val COLOR_DEFAULT_BLUE = 0xb30000ff.toInt()
+        private const val COLOR_DEFAULT_BLUE = 0xb30000ff.toInt()
 
         // parameters for storing extra meta information for line coloring
         var KEY_CP_ALTITUDE_MANUAL = "alt_man"

--- a/locus-api-core/src/main/java/locus/api/objects/styles/LineStyle.kt
+++ b/locus-api-core/src/main/java/locus/api/objects/styles/LineStyle.kt
@@ -66,7 +66,7 @@ class LineStyle : Storable() {
     // flag to draw background
     var drawBase: Boolean = true
     // base background color
-    var colorBase: Int = COLOR_BLACK
+    var colorBase: Int = COLOR_DEFAULT_BLUE
     // flag to draw symbol
     var drawSymbol: Boolean = false
     // symbol coloring
@@ -78,7 +78,7 @@ class LineStyle : Storable() {
     // coloring parameters
     private val coloringParams: Hashtable<String, String> = Hashtable()
     // width of line [px | m]
-    var width: Float = 1.0f
+    var width: Float = 6.0f
     // width units
     var units: Units = Units.PIXELS
     // flag to draw outline
@@ -195,6 +195,8 @@ class LineStyle : Storable() {
         private const val COLOR_WHITE = -0x1
         // black color
         private const val COLOR_BLACK = -0x1000000
+        // Locus Map default line color — slightly transparent blue (#b30000ff)
+        private val COLOR_DEFAULT_BLUE = 0xb30000ff.toInt()
 
         // parameters for storing extra meta information for line coloring
         var KEY_CP_ALTITUDE_MANUAL = "alt_man"


### PR DESCRIPTION
Align LineStyle defaults with Locus Map defaults — translucent blue (#b30000ff) at 6px width instead of opaque black at 1px.

Changed
- Track styling: LineStyle.colorBase and width defaults match Locus Map defaults
- Docs: add [0.10.0] CHANGELOG entry; fix README setup snippets and release steps